### PR TITLE
CS0246 error: Type namespace ZXing could not be found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Installation
 Using CLI:
 * cordova plugin add org.bloxlab.barcodescanner (or substitute org.bloxlab.barcodescanner with https://github.com/bloxlab/BarcodeScannerWP8.git)
 * cordova build wp8
+* NOTE: If you see compile errors related to 'type or namespace "ZXing" could not be found', then right-click on Resources folder in Visual Studio Solution Explorer. From the menu select "Manage NuGet Packages..." and download ZXing.Net from Michael Jahn.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 Using CLI:
 * cordova plugin add org.bloxlab.barcodescanner (or substitute org.bloxlab.barcodescanner with https://github.com/bloxlab/BarcodeScannerWP8.git)
 * cordova build wp8
-* NOTE: If you see compile errors related to 'type or namespace "ZXing" could not be found', then right-click on Resources folder in Visual Studio Solution Explorer. From the menu select "Manage NuGet Packages..." and download ZXing.Net from Michael Jahn.
+* NOTE: If you see compile errors related to 'type or namespace "ZXing" could not be found', then right-click on References folder in Visual Studio Solution Explorer. From the menu select "Manage NuGet Packages..." and download ZXing.Net from Michael Jahn.
 
 
 Usage


### PR DESCRIPTION
Just used BarcodeScannerWP8 with Cordova. It went well and I'm happy with the way it works. 
I had a small hiccup during installation and have a suggestion for the README.md file:

After I ran the command:

"cordova plugin add org.bloxlab.barcodescanner"

 I saw that I was getting ZXing namespace errors during build process in both cordova CLI and Visual Studio.

I then realized that the compiler/linker wasn't able to find zxing.wp8.0.dll

I could see the dll in the following directories:
platforms\wp8\Plugins\org.bloxlab.barcodescanner
plugins\org.bloxlab\barcodescanner\src\wp8\dependencies.

I then attempted to "add" it to the References directory in Visual Studio, but Visual Studio complained with the message below:
"A reference to a higher version or incompatible assembly cannot be added to the project"
(I am using Visual Studio 11.0.61030.00 Update 4)

I did some googling and found out about another WP8 barcode project that recommended using nuGet to pull in XZing.Net. I tried that and and it solved my problem.

Not sure if this is an issue related to my environment, of if 'cordova plugin add' failed to put the dll in proper place, but thought I would share my sequence as well as proposed work-around.

Scott Larribeau
